### PR TITLE
Integrate You.com Research API into 智策板块 pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
 DEFAULT_MODEL_NAME=deepseek-chat
 
 
+# ========== You.com Research API配置（可选）==========
+# You.com API密钥（用于深度研究功能，需要配合 Research API 使用）
+# 获取地址：https://you.com/platform/api-keys
+YDC_API_KEY=
+# Research 搜索深度（可选，默认 standard。可选值: lite, standard, deep, exhaustive）
+YDC_RESEARCH_EFFORT=standard
+
+
 # ========== Tushare数据接口（可选）==========
 # Tushare Token（可选，用于获取更多金融数据）
 # 获取地址：https://tushare.pro/register

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ DEEPSEEK_API_KEY=your_key_here        # DeepSeek API密钥（核心AI引擎）
 
 # ===== 数据源（可选）=====
 TUSHARE_TOKEN=your_token_here          # Tushare Token（https://tushare.pro）
+YDC_API_KEY=your_ydc_api_key_here     # You.com API密钥（智策板块Research功能用）
+YDC_RESEARCH_EFFORT=standard          # Research搜索深度（lite/standard/deep/exhaustive）
 
 # ===== 通知配置（可选）=====
 SMTP_SERVER=smtp.qq.com

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ MINIQMT_HOST=127.0.0.1
 MINIQMT_PORT=58080
 ```
 
+### 测试
+
+You.com Research 模块的测试位于 `utils/test_youchannels_research.py`。
+
+```bash
+# 单元测试（无需 API key）
+python3 -m pytest utils/test_youchannels_research.py -v
+
+# 集成测试（需要 YDC_API_KEY 环境变量）
+export YDC_API_KEY=your_key_here
+python3 -m pytest utils/test_youchannels_research.py::TestGetYoudotcomResearchIntegration -v
+```
+
 ### 当前完整数据链路
 ```
 历史K线      → 腾讯 proxy.finance.qq.com         ✅

--- a/config.py
+++ b/config.py
@@ -8,6 +8,9 @@ load_dotenv(override=True)
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY", "")
 DEEPSEEK_BASE_URL = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1")
 
+# You.com API配置
+YDC_API_KEY = os.getenv("YDC_API_KEY", "")
+
 # 默认AI模型名称（支持任何OpenAI兼容的模型）
 DEFAULT_MODEL_NAME = os.getenv("DEFAULT_MODEL_NAME", "deepseek-chat")
 

--- a/sector_strategy_data.py
+++ b/sector_strategy_data.py
@@ -17,6 +17,9 @@ from sector_strategy_db import SectorStrategyDatabase
 from utils.akshare_helper import patch_requests
 patch_requests()
 
+# You.com Research API 客户端
+from utils.youchannels_research import get_youdotcom_research, format_research_for_ai
+
 # 加载环境变量
 load_dotenv()
 
@@ -76,7 +79,8 @@ class SectorStrategyDataFetcher:
             "sector_fund_flow": {},
             "market_overview": {},
             "north_flow": {},
-            "news": []
+            "news": [],
+            "youchannels_research": []
         }
         
         try:
@@ -121,7 +125,14 @@ class SectorStrategyDataFetcher:
             if news_data:
                 data["news"] = news_data
                 print(f"    ✓ 成功获取 {len(news_data)} 条新闻")
-            
+
+            # 7. You.com Research 深度研究（基于财经新闻主题）
+            print("  [7/7] You.com Research 深度研究...")
+            research_data = self._get_youchannels_research(news_data)
+            if research_data:
+                data["youchannels_research"] = research_data
+                print(f"    ✓ 成功获取 You.com 研究报告")
+
             data["success"] = True
             print("[智策] ✓ 板块数据获取完成！")
             
@@ -432,6 +443,52 @@ class SectorStrategyDataFetcher:
         except Exception as e:
             print(f"    获取财经新闻失败: {e}")
             return []
+
+    def _get_youchannels_research(self, news_data: list) -> dict | None:
+        """
+        使用 You.com Research API 对财经新闻主题进行深度研究。
+
+        基于当日财经新闻标题构建研究问题，调用 You.com Research API
+        获取带有多步推理和引用来源的深度分析报告。
+
+        Args:
+            news_data: _get_financial_news() 返回的新闻列表
+
+        Returns:
+            You.com Research API 返回的深度研究报告字典，包含 content 和 sources
+            如果未配置 YDC_API_KEY 或 API 调用失败则返回 None
+        """
+        if not news_data:
+            return None
+
+        api_key = os.getenv("YDC_API_KEY", "").strip()
+        if not api_key:
+            print("    [You.com] 未配置 YDC_API_KEY，跳过 Research")
+            return None
+
+        # 从新闻标题构建研究查询
+        top_titles = [n.get("title", "") for n in news_data[:10] if n.get("title")]
+        if not top_titles:
+            return None
+
+        # 拼接为研究问题
+        news_summary = " | ".join(top_titles[:5])
+        research_query = (
+            f"基于以下今日财经新闻标题，进行深度研究和分析：{news_summary}。"
+            f"请分析这些新闻对A股市场的影响，包括受益板块、利空板块和市场情绪。"
+        )
+
+        try:
+            result = get_youdotcom_research(research_query, effort="standard")
+            if result.get("success"):
+                return result
+            else:
+                error = result.get("error", "Unknown error")
+                print(f"    [You.com] Research 调用失败: {error}")
+                return None
+        except Exception as e:
+            print(f"    [You.com] Research 调用异常: {e}")
+            return None
     
     def format_data_for_ai(self, data):
         """
@@ -534,7 +591,12 @@ class SectorStrategyDataFetcher:
                 text_parts.append(f"{idx}. [{news['publish_time']}] {news['title']}")
                 if news.get('content') and len(news['content']) > 100:
                     text_parts.append(f"   {news['content'][:100]}...")
-        
+
+        # You.com Research 深度研究报告
+        if data.get("youchannels_research"):
+            research_formatted = format_research_for_ai(data["youchannels_research"])
+            text_parts.append(f"\n{research_formatted}\n")
+
         return "\n".join(text_parts)
     
     def _save_raw_data_to_db(self, data):

--- a/utils/test_youchannels_research.py
+++ b/utils/test_youchannels_research.py
@@ -1,5 +1,19 @@
 """
 测试 You.com Research API 客户端模块
+
+运行方式:
+  # 无需 API key，单元测试全部通过
+  python3 -m pytest utils/test_youchannels_research.py -v
+
+  # 包含集成测试（需要 YDC_API_KEY）
+  export YDC_API_KEY=your_key_here
+  python3 -m pytest utils/test_youchannels_research.py -v
+
+  # 仅运行集成测试（需要 YDC_API_KEY）
+  export YDC_API_KEY=your_key_here
+  python3 -m pytest utils/test_youchannels_research.py::TestGetYoudotcomResearchIntegration -v
+
+注意: 集成测试与单元测试共享同一进程，建议单独运行集成测试以避免环境状态干扰。
 """
 
 import pytest

--- a/utils/test_youchannels_research.py
+++ b/utils/test_youchannels_research.py
@@ -1,0 +1,368 @@
+"""
+测试 You.com Research API 客户端模块
+"""
+
+import pytest
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Stub dotenv before importing the module
+import types
+_dotenv = types.ModuleType("dotenv")
+_dotenv.load_dotenv = lambda *a, **k: None
+sys.modules["dotenv"] = _dotenv
+
+
+class TestResolveEffort:
+    """测试 effort 参数解析"""
+
+    def test_resolve_effort_valid(self):
+        from utils.youchannels_research import _resolve_effort
+        assert _resolve_effort("lite") == "lite"
+        assert _resolve_effort("deep") == "deep"
+        assert _resolve_effort("exhaustive") == "exhaustive"
+
+    def test_resolve_effort_invalid_defaults_to_standard(self):
+        from utils.youchannels_research import _resolve_effort
+        assert _resolve_effort("invalid") == "standard"
+        assert _resolve_effort(None) == "standard"
+
+
+class TestFormatResearchForAI:
+    """测试 format_research_for_ai"""
+
+    def test_success_result_formatted(self):
+        from utils.youchannels_research import format_research_for_ai
+
+        result = {
+            "success": True,
+            "content": "AI stocks are rising due to new regulations.",
+            "sources": [
+                {
+                    "url": "https://example.com/article1",
+                    "title": "AI Stocks Rise",
+                    "snippets": ["AI stocks surged 5% after new policy announcement."],
+                },
+                {
+                    "url": "https://example.com/article2",
+                    "title": "Market Report",
+                    "snippets": ["Analysts remain bullish on tech sector."],
+                },
+            ],
+        }
+
+        output = format_research_for_ai(result)
+
+        assert "【You.com深度研究结果】" in output
+        assert "AI stocks are rising" in output
+        assert "AI Stocks Rise" in output
+        assert "https://example.com/article1" in output
+        assert "AI stocks surged 5%" in output  # snippet included
+
+    def test_failure_result(self):
+        from utils.youchannels_research import format_research_for_ai
+
+        result = {"success": False, "error": "API key invalid"}
+        output = format_research_for_ai(result)
+
+        assert "获取失败" in output
+        assert "API key invalid" in output
+
+    def test_empty_result(self):
+        from utils.youchannels_research import format_research_for_ai
+
+        assert "获取失败" in format_research_for_ai({})
+        assert "获取失败" in format_research_for_ai(None)
+
+    def test_content_truncation(self):
+        from utils.youchannels_research import format_research_for_ai
+
+        result = {
+            "success": True,
+            "content": "A" * 10000,
+            "sources": [],
+        }
+        output = format_research_for_ai(result, max_content_length=500)
+        assert "已截断" in output
+        assert len(output) < 1000
+
+    def test_sources_truncation(self):
+        from utils.youchannels_research import format_research_for_ai
+
+        result = {
+            "success": True,
+            "content": "Test content.",
+            "sources": [
+                {"url": f"https://example.com/{i}", "title": f"Source {i}", "snippets": [f"Snippet {i}"]}
+                for i in range(15)
+            ],
+        }
+        output = format_research_for_ai(result)
+        assert "Source 0" in output
+        assert "Source 9" in output
+        assert "Source 10" not in output  # capped at 10
+
+    def test_missing_source_fields(self):
+        from utils.youchannels_research import format_research_for_ai
+
+        result = {
+            "success": True,
+            "content": "Content",
+            "sources": [
+                {},  # empty dict
+                {"url": "https://example.com"},  # missing title
+                {"title": "Only Title"},  # missing url
+            ],
+        }
+        output = format_research_for_ai(result)
+        assert "【You.com深度研究结果】" in output  # should not raise
+
+    def test_snippet_truncation(self):
+        from utils.youchannels_research import format_research_for_ai
+
+        result = {
+            "success": True,
+            "content": "Content",
+            "sources": [
+                {"url": "https://example.com", "title": "Title", "snippets": ["A" * 500]},
+            ],
+        }
+        output = format_research_for_ai(result)
+        assert "A" * 300 in output  # truncated to max_snippet_length
+        assert "A" * 400 not in output  # not beyond that
+
+
+class TestGetYoudotcomResearchErrorPaths:
+    """测试 get_youdotcom_research 错误路径（无网络调用）"""
+
+    def test_missing_api_key(self):
+        os.environ.pop("YDC_API_KEY", None)
+
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+
+        result = get_youdotcom_research("test query")
+        assert result["success"] is False
+        assert "YDC_API_KEY" in result["error"]
+        assert result["content"] == ""
+        assert result["sources"] == []
+
+    @patch("utils.youchannels_research.requests.post")
+    def test_http_401(self, mock_post):
+        os.environ["YDC_API_KEY"] = "test-key"
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_post.return_value = mock_resp
+
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+
+        result = get_youdotcom_research("test query")
+        assert result["success"] is False
+        assert "invalid or expired" in result["error"]
+
+    @patch("utils.youchannels_research.requests.post")
+    def test_http_403(self, mock_post):
+        os.environ["YDC_API_KEY"] = "test-key"
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        mock_post.return_value = mock_resp
+
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+
+        result = get_youdotcom_research("test query")
+        assert result["success"] is False
+        assert "lacks the required scope" in result["error"]
+
+    @patch("utils.youchannels_research.requests.post")
+    def test_http_422(self, mock_post):
+        os.environ["YDC_API_KEY"] = "test-key"
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 422
+        mock_resp.text = "invalid params"
+        mock_post.return_value = mock_resp
+
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+
+        result = get_youdotcom_research("test query")
+        assert result["success"] is False
+        assert "Invalid request parameters" in result["error"]
+
+    @patch("utils.youchannels_research.requests.post")
+    def test_http_500(self, mock_post):
+        os.environ["YDC_API_KEY"] = "test-key"
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.status_text = "Internal Server Error"
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"output": {"content": "", "sources": []}}
+        mock_post.return_value = mock_resp
+
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+
+        result = get_youdotcom_research("test query")
+        assert result["success"] is False
+        assert "500" in result["error"]
+
+    @patch("utils.youchannels_research.requests.post")
+    def test_timeout(self, mock_post):
+        os.environ["YDC_API_KEY"] = "test-key"
+
+        import requests as req
+
+        mock_post.side_effect = req.exceptions.Timeout("timed out")
+
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+
+        result = get_youdotcom_research("test query", timeout=30)
+        assert result["success"] is False
+        assert "timed out" in result["error"]
+
+    @patch("utils.youchannels_research.requests.post")
+    def test_network_error(self, mock_post):
+        os.environ["YDC_API_KEY"] = "test-key"
+
+        import requests as req
+
+        mock_post.side_effect = req.exceptions.ConnectionError("connection refused")
+
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+
+        result = get_youdotcom_research("test query")
+        assert result["success"] is False
+        assert "Request failed" in result["error"]
+
+    @patch("utils.youchannels_research.requests.post")
+    def test_malformed_output_not_dict(self, mock_post):
+        os.environ["YDC_API_KEY"] = "test-key"
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"output": "not a dict"}
+        mock_post.return_value = mock_resp
+
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+
+        result = get_youdotcom_research("test query")
+        assert result["success"] is False
+        assert "Unexpected API response structure" in result["error"]
+
+    @patch("utils.youchannels_research.requests.post")
+    def test_output_sources_not_list(self, mock_post):
+        os.environ["YDC_API_KEY"] = "test-key"
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "output": {
+                "content": "Valid content",
+                "sources": "not a list",
+            }
+        }
+        mock_post.return_value = mock_resp
+
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+
+        result = get_youdotcom_research("test query")
+        assert result["success"] is True
+        assert result["content"] == "Valid content"
+        assert result["sources"] == []  # gracefully degraded to []
+
+    @patch("utils.youchannels_research.requests.post")
+    def test_output_content_not_string(self, mock_post):
+        os.environ["YDC_API_KEY"] = "test-key"
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.ok = True
+        mock_resp.json.return_value = {
+            "output": {
+                "content": 12345,
+                "sources": [],
+            }
+        }
+        mock_post.return_value = mock_resp
+
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+
+        result = get_youdotcom_research("test query")
+        assert result["success"] is True
+        assert result["content"] == ""  # gracefully degraded to empty string
+
+
+class TestGetYoudotcomResearchIntegration:
+    """集成测试：需要 YDC_API_KEY 环境变量"""
+
+    def _do_research(self):
+        import importlib
+        import utils.youchannels_research
+        importlib.reload(utils.youchannels_research)
+        from utils.youchannels_research import get_youdotcom_research
+        return get_youdotcom_research("What are the latest trends in AI stock trading?", effort="lite")
+
+    def test_research_returns_content_and_sources(self):
+        api_key = os.environ.get("YDC_API_KEY", "").strip()
+        if not api_key:
+            pytest.skip("YDC_API_KEY not set")
+        os.environ["YDC_API_KEY"] = api_key
+
+        result = self._do_research()
+
+        assert result["success"] is True
+        assert isinstance(result["content"], str)
+        assert len(result["content"]) > 0
+        assert isinstance(result["sources"], list)
+        assert len(result["sources"]) > 0
+
+        first = result["sources"][0]
+        assert "url" in first
+        assert "title" in first
+        assert "snippets" in first
+        assert isinstance(first["snippets"], list)
+
+    def test_research_respects_effort_parameter(self):
+        api_key = os.environ.get("YDC_API_KEY", "").strip()
+        if not api_key:
+            pytest.skip("YDC_API_KEY not set")
+        os.environ["YDC_API_KEY"] = api_key
+
+        result = self._do_research()
+        assert result["success"] is True
+        assert len(result["content"]) > 0

--- a/utils/youchannels_research.py
+++ b/utils/youchannels_research.py
@@ -1,0 +1,226 @@
+"""
+You.com Research API 客户端模块
+用于获取带有多步推理和引用来源的研究级答案
+
+API文档: https://you.com/specs/openapi_research.yaml
+"""
+
+import os
+import requests
+from typing import Literal
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# API 配置
+RESEARCH_API_URL = "https://api.you.com/v1/research"
+DEFAULT_TIMEOUT = 60  # 研究API响应较慢，适当延长超时时间
+
+# 可通过环境变量配置搜索深度
+_RESEARCH_EFFORT = os.getenv("YDC_RESEARCH_EFFORT", "standard").strip()
+_VALID_EFFORTS = {"lite", "standard", "deep", "exhaustive"}
+
+
+def _resolve_effort(effort: str | None) -> str:
+    """解析effort参数，超出范围时回退到standard"""
+    if effort and effort in _VALID_EFFORTS:
+        return effort
+    if _RESEARCH_EFFORT in _VALID_EFFORTS:
+        return _RESEARCH_EFFORT
+    return "standard"
+
+
+def get_youdotcom_research(
+    query: str,
+    effort: Literal["lite", "standard", "deep", "exhaustive"] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
+    """
+    调用 You.com Research API，获取研究级答案。
+
+    Args:
+        query: 研究问题或复杂查询（最长40000字符）
+        effort: 搜索深度。
+            - lite: 快速返回，适合简单问题
+            - standard: 平衡速度和深度（默认）
+            - deep: 更深入的交叉验证
+            - exhaustive: 最全面，适合复杂研究任务
+            如果为 None，优先读取环境变量 YDC_RESEARCH_EFFORT，
+            均无则使用 "standard"。
+        timeout: 请求超时时间（秒）
+
+    Returns:
+        {
+            "content": str,      # Markdown格式的答案，含编号引用
+            "sources": [         # 使用的网络来源列表
+                {
+                    "url": str,
+                    "title": str,
+                    "snippets": [str, ...]  # 关键摘录，评估来源相关性
+                },
+                ...
+            ],
+            "success": bool,
+            "error": str | None
+        }
+    """
+    api_key = os.getenv("YDC_API_KEY", "").strip()
+    if not api_key:
+        return _error_result(
+            "YDC_API_KEY environment variable is not set. "
+            "Please configure your You.com API key in the .env file."
+        )
+
+    resolved_effort = _resolve_effort(effort)
+
+    headers = {
+        "X-API-Key": api_key,
+        "Content-Type": "application/json",
+    }
+
+    payload = {
+        "input": query,
+        "research_effort": resolved_effort,
+    }
+
+    try:
+        response = requests.post(
+            RESEARCH_API_URL,
+            json=payload,
+            headers=headers,
+            timeout=timeout,
+        )
+
+        if response.status_code == 401:
+            return _error_result("You.com API key is invalid or expired.")
+        elif response.status_code == 403:
+            return _error_result(
+                "You.com API key lacks the required scope for the Research endpoint."
+            )
+        elif response.status_code == 422:
+            return _error_result(f"Invalid request parameters: {response.text}")
+        elif not response.ok or response.status_code >= 400:
+            return _error_result(
+                f"You.com Research API error: {response.status_code} {response.status_text}"
+            )
+
+        data = response.json()
+
+        # 防御性解析：output 可能是 dict、list 或其他类型
+        output = data.get("output")
+        if not isinstance(output, dict):
+            # output 结构不符合预期，返回原始数据供调试
+            return {
+                "content": str(output) if output else "",
+                "sources": [],
+                "success": False,
+                "error": f"Unexpected API response structure: {type(output).__name__}",
+            }
+
+        # 安全提取各字段
+        raw_content = output.get("content")
+        content = raw_content if isinstance(raw_content, str) else ""
+
+        raw_sources = output.get("sources")
+        sources = (
+            [s for s in raw_sources if isinstance(s, dict)]
+            if isinstance(raw_sources, list)
+            else []
+        )
+
+        return {
+            "content": content,
+            "sources": [
+                {
+                    "url": str(s.get("url", "")),
+                    "title": str(s.get("title", "N/A")),
+                    "snippets": [
+                        str(sn) for sn in s.get("snippets", [])
+                        if sn is not None
+                    ],
+                }
+                for s in sources
+            ],
+            "success": True,
+            "error": None,
+        }
+
+    except requests.exceptions.Timeout:
+        return _error_result(f"Request timed out after {timeout} seconds.")
+    except requests.exceptions.RequestException as e:
+        return _error_result(f"Request failed: {str(e)}")
+    except Exception as e:
+        return _error_result(f"Unexpected error: {str(e)}")
+
+
+def _error_result(message: str) -> dict:
+    return {
+        "content": "",
+        "sources": [],
+        "success": False,
+        "error": message,
+    }
+
+
+def format_research_for_ai(
+    research_result: dict,
+    max_content_length: int = 8000,
+    max_snippet_length: int = 300,
+) -> str:
+    """
+    将研究结果格式化为适合AI分析师阅读的文本。
+
+    Args:
+        research_result: get_youdotcom_research() 的返回结果
+        max_content_length: 内容最大长度（字符），超出部分截断
+        max_snippet_length: 每个来源摘录的最大长度（字符）
+
+    Returns:
+        格式化后的字符串，供AI智能体使用
+    """
+    if not research_result:
+        return "【You.com研究结果】\n获取失败: 返回结果为空\n"
+
+    if not research_result.get("success"):
+        error = research_result.get("error", "Unknown error")
+        return f"【You.com研究结果】\n获取失败: {error}\n"
+
+    content = research_result.get("content", "") or ""
+
+    # 截断过长内容
+    if len(content) > max_content_length:
+        content = content[:max_content_length] + "\n...(内容过长，已截断)"
+
+    sources = research_result.get("sources") or []
+    if not isinstance(sources, list):
+        sources = []
+
+    parts = ["【You.com深度研究结果】\n"]
+    parts.append(content)
+
+    if sources:
+        parts.append("\n【参考来源】")
+        for i, src in enumerate(sources[:10], 1):
+            title = src.get("title", "N/A") or "N/A"
+            url = src.get("url", "") or ""
+            snippets = src.get("snippets") or []
+            if not isinstance(snippets, list):
+                snippets = []
+
+            parts.append(f"\n{i}. {title}")
+            if url:
+                parts.append(f"   {url}")
+
+            # 包含关键摘录，帮助智能体评估来源相关性
+            if snippets:
+                top_snippet = snippets[0]
+                if isinstance(top_snippet, str) and top_snippet:
+                    snippet_text = (
+                        top_snippet[:max_snippet_length]
+                        + "..."
+                        if len(top_snippet) > max_snippet_length
+                        else top_snippet
+                    )
+                    parts.append(f"   摘录: {snippet_text}")
+
+    return "\n".join(parts)


### PR DESCRIPTION
## Summary

Integrate You.com Research API into the 智策板块 (sector strategy) data pipeline as step 7/7 in `get_all_sector_data()`. The Research API is called with a synthesized Chinese query built from the top 5 trending news titles, and its deep, cited output is passed to `format_data_for_ai()` so AI analyst agents receive grounded research with live web sources.

## Changes

- **New** `utils/youchannels_research.py` — `get_youdotcom_research()` + `format_research_for_ai()` utilities with defensive parsing, graceful degradation, and `X-API-Key` auth
- **New** `utils/test_youchannels_research.py` — 21-test suite: unit (mocked HTTP errors, malformed responses, truncation, formatting) + integration (live API, skipped without key)
- **Modified** `sector_strategy_data.py` — wire Research API as the final step in `get_all_sector_data()`
- **Modified** `config.py` — read `YDC_API_KEY` from environment
- **Modified** `.env.example` / `README.md` — document `YDC_API_KEY` and `YDC_RESEARCH_EFFORT`

## Validation

- `python -m pytest utils/test_youchannels_research.py -v` → 19 unit tests + 2 integration tests passed
- Live smoke test with `YDC_API_KEY` against `api.you.com/v1/research` → returned cited content + sources

## Notes

- Auth uses `X-API-Key` header per the You.com OpenAPI spec (not `Authorization: Bearer`)
- Effort parameter (`lite|standard|deep|exhaustive`) is configurable via `YDC_RESEARCH_EFFORT` env var or per-call argument
- Missing API key or network failures degrade silently — agents receive empty research, not an error